### PR TITLE
Fixed a bug when loading models

### DIFF
--- a/purls/algorithms/base.py
+++ b/purls/algorithms/base.py
@@ -73,7 +73,7 @@ class ReinforcementLearningAlgorithm(ABC):
         """
         Load a model. Used by visualize and evaluate to load a trained model.
         """
-        files = [f.split(".pt")[0] for f in os.listdir("models") if f != ".gitignore"]
+        files = [f.rpartition(".pt")[0] for f in os.listdir("models") if f != ".gitignore"]
         if self.model_name not in files:
             valid_model_names = ", ".join(files)
             raise AlgorithmError(f"Choose a valid model name: {valid_model_names}")


### PR DESCRIPTION
Small bug when using strip that prevented user to use a `--model-name` that starts with an p or an t.